### PR TITLE
Added Display Settings Composable

### DIFF
--- a/.idea/kotlinScripting.xml
+++ b/.idea/kotlinScripting.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="KotlinScriptingSettings" supportWarning="false" />
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AutoImportSettings">
+    <option name="autoReloadType" value="NONE" />
+  </component>
+  <component name="ChangeListManager">
+    <list default="true" id="b2473489-9b9f-48ee-9b7a-f4bc8cb65ea2" name="Changes" comment="">
+      <change afterPath="$PROJECT_DIR$/BusApp/app/src/main/java/edu/uga/acm/osp/composables/DisplaySettings.kt" afterDir="false" />
+    </list>
+    <option name="SHOW_DIALOG" value="false" />
+    <option name="HIGHLIGHT_CONFLICTS" value="true" />
+    <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
+    <option name="LAST_RESOLUTION" value="IGNORE" />
+  </component>
+  <component name="Git.Settings">
+    <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
+  </component>
+  <component name="MarkdownSettingsMigration">
+    <option name="stateVersion" value="1" />
+  </component>
+  <component name="ProjectId" id="2X0BwuLH3Tv7uDp8JHlL9kE1o6z" />
+  <component name="ProjectViewState">
+    <option name="hideEmptyMiddlePackages" value="true" />
+    <option name="showLibraryContents" value="true" />
+  </component>
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "RunOnceActivity.OpenProjectViewOnStart": "true",
+    "RunOnceActivity.ShowReadmeOnStart": "true",
+    "RunOnceActivity.cidr.known.project.marker": "true",
+    "cidr.known.project.marker": "true",
+    "last_opened_file_path": "C:/Users/nived/OneDrive/Documents/GitHub/ACM-OSP-Fall-2023/BusApp"
+  },
+  "keyToStringList": {
+    "com.intellij.ide.scratch.ScratchImplUtil$2/New Scratch File": [
+      "kotlin"
+    ]
+  }
+}]]></component>
+  <component name="SpellCheckerSettings" RuntimeDictionaries="0" Folders="0" CustomDictionaries="0" DefaultDictionary="application-level" UseSingleDictionary="true" transferred="true" />
+  <component name="TaskManager">
+    <task active="true" id="Default" summary="Default task">
+      <changelist id="b2473489-9b9f-48ee-9b7a-f4bc8cb65ea2" name="Changes" comment="" />
+      <created>1697756362109</created>
+      <option name="number" value="Default" />
+      <option name="presentableId" value="Default" />
+      <updated>1697756362109</updated>
+    </task>
+    <servers />
+  </component>
+  <component name="XDebuggerManager">
+    <breakpoint-manager>
+      <breakpoints>
+        <line-breakpoint enabled="true" type="kotlin-line">
+          <url>file://$PROJECT_DIR$/BusApp/app/src/main/java/edu/uga/acm/osp/nav/SettingScreen.kt</url>
+          <line>10</line>
+          <option name="timeStamp" value="1" />
+        </line-breakpoint>
+      </breakpoints>
+    </breakpoint-manager>
+  </component>
+</project>

--- a/BusApp/app/src/main/java/edu/uga/acm/osp/composables/DisplaySettings.kt
+++ b/BusApp/app/src/main/java/edu/uga/acm/osp/composables/DisplaySettings.kt
@@ -1,0 +1,209 @@
+package edu.uga.acm.osp.composables
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.material.Card
+import androidx.compose.material.DropdownMenu
+import androidx.compose.material.DropdownMenuItem
+import androidx.compose.material.Switch
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+
+
+@Preview(showBackground = true)
+@Composable
+fun DisplayBox() {
+    Card {
+        Row (modifier = Modifier.padding(24.dp)) {
+            Column(
+                modifier = Modifier
+                    .padding(bottom = 48.dp)
+                    .padding(bottom = 48.dp)
+
+            ) {
+                Row {
+                    Column{
+                        Text(text = "Display Settings", fontWeight = FontWeight.ExtraBold)
+                    }
+                }
+                Row {
+                    Column(
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        Text(text = "Dark Mode: ")
+                    }
+                    Column{
+                        toggleButton()
+                    }
+                }
+                Row {
+                    Column{
+                        Text(text = "Distance Units: ")
+                    }
+                    Column{
+                        DropdownDistance()
+                    }
+
+                }
+                Row{
+                    Column{
+                        Text(text = "Time Format: ")
+                    }
+                    Column{
+                        DropdownTime()
+                    }
+                }
+                Row {
+                    Column{
+                        Text(text = "Language: ")
+                    }
+                    Column{
+                        DropdownLanguage()
+                    }
+                }
+            }
+        }
+    }
+}
+@Composable
+fun toggleButton() {
+    var checked by remember { mutableStateOf(true) }
+
+    Switch(
+        checked = checked,
+        onCheckedChange = {
+            checked = it
+        }
+    )
+}
+
+@Composable
+fun DropdownDistance() {
+    var expanded by remember { mutableStateOf(false) }
+    val items = listOf("Miles/Feet", "Meters/Kilometers")
+    val disabledValue = "B"
+    var selectedIndex by remember { mutableStateOf(0) }
+    Box(modifier = Modifier
+        .wrapContentSize(Alignment.TopStart)) {
+        Text(items[selectedIndex],modifier = Modifier
+            .clickable(onClick = { expanded = true })
+            .background(
+                Color.LightGray
+            ))
+        DropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false },
+            modifier = Modifier
+                .background(
+                    Color.LightGray
+                )
+        ) {
+            items.forEachIndexed { index, s ->
+                DropdownMenuItem(onClick = {
+                    selectedIndex = index
+                    expanded = false
+                }) {
+                    val disabledText = if (s == disabledValue) {
+                        " (Disabled)"
+                    } else {
+                        ""
+                    }
+                    Text(text = s + disabledText)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun DropdownTime() {
+    var expanded by remember { mutableStateOf(false) }
+    val items = listOf("12-Hour Format", "24-Hour Format")
+    val disabledValue = "B"
+    var selectedIndex by remember { mutableStateOf(0) }
+    Box(modifier = Modifier
+        .wrapContentSize(Alignment.TopStart)) {
+        Text(items[selectedIndex],modifier = Modifier
+            .clickable(onClick = { expanded = true })
+            .background(
+                Color.LightGray
+            ))
+        DropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false },
+            modifier = Modifier
+                .background(
+                    Color.LightGray
+                )
+        ) {
+            items.forEachIndexed { index, s ->
+                DropdownMenuItem(onClick = {
+                    selectedIndex = index
+                    expanded = false
+                }) {
+                    val disabledText = if (s == disabledValue) {
+                        " (Disabled)"
+                    } else {
+                        ""
+                    }
+                    Text(text = s + disabledText)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun DropdownLanguage() {
+    var expanded by remember { mutableStateOf(false) }
+    val items = listOf("English")
+    val disabledValue = "B"
+    var selectedIndex by remember { mutableStateOf(0) }
+    Box(modifier = Modifier
+        .wrapContentSize(Alignment.TopStart)) {
+        Text(items[selectedIndex],modifier = Modifier
+            .clickable(onClick = { expanded = true })
+            .background(
+                Color.LightGray
+            ))
+        DropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false },
+            modifier = Modifier
+                .background(
+                    Color.LightGray
+                )
+        ) {
+            items.forEachIndexed { index, s ->
+                DropdownMenuItem(onClick = {
+                    selectedIndex = index
+                    expanded = false
+                }) {
+                    val disabledText = if (s == disabledValue) {
+                        " (Disabled)"
+                    } else {
+                        ""
+                    }
+                    Text(text = s + disabledText)
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
I added the display settings composable, which contains the settings features for toggling dark mode, changing the distance units (feet/miles vs km/m), changing the time format (12 hour vs 24 hour), and changing the language preferenced (currently English is the only option to select but we can proabably add on if we want to develop this).